### PR TITLE
(fix): multisite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ See [config](./config/user-roles.php) for all configuration options.
 
 2. Run WP-CLI command to create roles:
 
+    Single site:
+
    ```shell
    wp acorn roles:create
    ```
+
+    In a multisite:
+
+    ```shell
+    wp site list --field=url | xargs -n1 -I % wp acorn roles:create --url=% 
+    ```

--- a/src/Console/UserRolesCommand.php
+++ b/src/Console/UserRolesCommand.php
@@ -33,13 +33,6 @@ class UserRolesCommand extends Command
 
 	private function createRolesForSites(): void
 	{
-		if (true === is_multisite()) {
-			foreach (get_sites(['fields' => 'ids']) as $siteId) {
-				switch_to_blog($siteId);
-				UserRoles::createRoles();
-			}
-		} else {
-			UserRoles::createRoles();
-		}
+		UserRoles::createRoles();
 	}
 }

--- a/tests/Console/UserRolesCommandTest.php
+++ b/tests/Console/UserRolesCommandTest.php
@@ -4,33 +4,8 @@ declare(strict_types=1);
 
 use Facades\Yard\UserRoles\UserRoles;
 
-it('creates roles once when not in multisite', function () {
-	WP_Mock::userFunction('is_multisite', [
-		'return' => false,
-	]);
-
+it('creates roles once ', function () {
 	UserRoles::shouldReceive('createRoles')->once();
-
-	$this->artisan('roles:create')
-		->expectsOutput('Updating roles...')
-		->expectsOutput('All done!')
-		->assertExitCode(0);
-});
-
-it('creates roles for each site when in multisite', function () {
-	WP_Mock::userFunction('is_multisite', [
-		'return' => true,
-	]);
-
-	WP_Mock::userFunction('get_sites', [
-		'return' => [1, 2, 3],
-	]);
-
-	WP_Mock::userFunction('switch_to_blog', [
-		'times' => 3,
-	]);
-
-	UserRoles::shouldReceive('createRoles')->times(3);
 
 	$this->artisan('roles:create')
 		->expectsOutput('Updating roles...')


### PR DESCRIPTION
switch_blog does not load the theme from the subsite, therefore the config from the main site is always use.
